### PR TITLE
Added checks to remove build errors for non-Editor file SfxrAudioPlayer

### DIFF
--- a/source/SfxrAudioPlayer.cs
+++ b/source/SfxrAudioPlayer.cs
@@ -1,7 +1,11 @@
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using UnityEngine;
 
+#if UNITY_EDITOR
 [ExecuteInEditMode]
+#endif
 public class SfxrAudioPlayer : MonoBehaviour {
 
 	/**
@@ -73,7 +77,9 @@ public class SfxrAudioPlayer : MonoBehaviour {
 					// When running in edit mode, Update() is not called on every frame
 					// We can't call Destroy() directly either, since Destroy() must be ran from the main thread
 					// So we just attach out Update() to the editor's update event
+#if UNITY_EDITOR
 					EditorApplication.update += Update;
+#endif
 				}
 			}
 		}
@@ -101,7 +107,9 @@ public class SfxrAudioPlayer : MonoBehaviour {
 			if (runningInEditMode) {
 				// Since we're running in the editor, we need to remove the update event, AND destroy immediately
 				UnityEngine.Object.DestroyImmediate(gameObject);
+#if UNITY_EDITOR
 				EditorApplication.update -= Update;
+#endif
 			} else {
 				UnityEngine.Object.Destroy(gameObject);
 			}


### PR DESCRIPTION
Without this preprocess check added, building for iOS/Android was failing for me because of this file.

It can't be moved to the Editor directory because it is used in final builds, but it can't be used in final builds with links to UnityEditor.
