### PR TITLE
Save sounds and reuse them with new SfxrSound

### DIFF
--- a/source/Editor/SfxrGenerator.cs
+++ b/source/Editor/SfxrGenerator.cs
@@ -60,6 +60,17 @@ public class SfxrGenerator : EditorWindow {
 	
 	private SfxrSynth synth;
 
+	private string soundTitle = String.Empty;
+	private SfxrSoundContainer soundContainer = null;
+	private SfxrSoundContainer SoundContainer {
+		get {
+			if (soundContainer == null)
+				soundContainer = SfxrSoundContainer.Create();
+
+			return soundContainer;
+		}
+	}
+
 	// ================================================================================================================
 	// PUBLIC INTERFACE -----------------------------------------------------------------------------------------------
 
@@ -213,6 +224,62 @@ public class SfxrGenerator : EditorWindow {
 				synth.parameters.SetSettingsString(parameters.GetSettingsString());
 				File.WriteAllBytes(path, synth.GetWavFile());
 			}
+		}
+
+		GUILayout.Space(30);
+
+		soundTitle = GUILayout.TextField(soundTitle);
+		bool canSave = !string.IsNullOrEmpty(soundTitle)
+					&& !soundTitle.Contains(";")
+					&& !soundTitle.Contains(":");
+		bool mustReplace = canSave && SoundContainer.Contains(soundTitle);
+		string buttonName = "SAVE";
+		if (!canSave)
+			buttonName = "INVALID NAME";
+		else if (mustReplace)
+			buttonName = "REPLACE";
+		else
+			buttonName = "SAVE";
+
+		if (!canSave) {
+			bool prevVal = GUI.enabled;
+			GUI.enabled = false;
+			GUILayout.Button(buttonName);
+			GUI.enabled = prevVal;
+		} else {
+			if (GUILayout.Button(buttonName)) {
+				string soundParams = parameters.GetSettingsString();
+
+				if (mustReplace) {
+					SoundContainer.ReplaceSound(soundTitle, soundParams);
+				} else {
+					SoundContainer.AddSound(soundTitle, soundParams);
+				}
+			}
+		}
+
+		if (canSave && mustReplace) {
+			if (GUILayout.Button("LOAD")) {
+				string soundParams = SoundContainer.GetSound(soundTitle);
+				parameters.SetSettingsString(soundParams);
+				soundChanged = true;
+			}
+		} else {
+			bool prevVal = GUI.enabled;
+			GUI.enabled = false;
+			GUILayout.Button("LOAD");
+			GUI.enabled = prevVal;
+		}
+
+		if (canSave && mustReplace) {
+			if (GUILayout.Button("DELETE")) {
+				SoundContainer.DeleteSound(soundTitle);
+			}
+		} else {
+			bool prevVal = GUI.enabled;
+			GUI.enabled = false;
+			GUILayout.Button("DELETE");
+			GUI.enabled = prevVal;
 		}
 
 		// End generator column

--- a/source/Editor/SfxrSoundEditor.cs
+++ b/source/Editor/SfxrSoundEditor.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+[CustomPropertyDrawer(typeof(SfxrSound))]
+public class SfxrSoundEditor : PropertyDrawer {
+
+	public override float GetPropertyHeight(SerializedProperty property, GUIContent label) {
+		if (property.isExpanded)
+			return EditorGUIUtility.singleLineHeight * 5;
+		else
+			return EditorGUIUtility.singleLineHeight;
+	}
+
+	public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
+		if (property.isExpanded)
+			DrawUnfolded(position, property, label);
+		else
+			DrawFolded(position, property, label);
+	}
+
+	private void DrawFolded(Rect position, SerializedProperty property, GUIContent label) {
+		var soundProperty = property.FindPropertyRelative("sound");
+		string sound = soundProperty.stringValue;
+		if (string.IsNullOrEmpty(sound))
+			property.isExpanded = EditorGUI.Foldout(position, property.isExpanded, property.displayName + " (" + sound + ")");
+		else
+			property.isExpanded = EditorGUI.Foldout(position, property.isExpanded, property.displayName);
+	}
+
+	private void DrawUnfolded(Rect position, SerializedProperty property, GUIContent label) {
+		Rect labelRect = new Rect(position.xMin, position.yMin, position.width, EditorGUIUtility.singleLineHeight);
+		Rect dropdownRect = new Rect(position.xMin, labelRect.yMax, position.width, EditorGUIUtility.singleLineHeight);
+		Rect cachedRect = new Rect(position.xMin, dropdownRect.yMax, position.width, EditorGUIUtility.singleLineHeight);
+		Rect mutationsRect = new Rect(position.xMin, cachedRect.yMax, position.width, EditorGUIUtility.singleLineHeight);
+		Rect factorRect = new Rect(position.xMin, mutationsRect.yMax, position.width, EditorGUIUtility.singleLineHeight);
+
+		var soundProperty = property.FindPropertyRelative("sound");
+		var cachedProperty = property.FindPropertyRelative("cached");
+		var mutationsProperty = property.FindPropertyRelative("mutations");
+		var factorProperty = property.FindPropertyRelative("mutationFactor");
+
+		var soundContainer = SfxrSoundContainer.Create();
+
+		string soundTitle = soundProperty.stringValue;
+		if (string.IsNullOrEmpty(soundTitle))
+			property.isExpanded = EditorGUI.Foldout(labelRect, property.isExpanded, property.displayName);
+		else
+			property.isExpanded = EditorGUI.Foldout(labelRect, property.isExpanded, property.displayName + " (" + soundTitle + ")");
+
+		if (soundContainer.IsEmpty) {
+			EditorGUI.Popup(dropdownRect, "Sound", 0, new string[] { "-" });
+		} else {
+			string sound = soundProperty.stringValue;
+			List<string> titles = new List<string>(soundContainer.GetTitles());
+			int newIdx = 0;
+			if (!string.IsNullOrEmpty(sound) && titles.Contains(sound)) {
+				int idx = titles.IndexOf(sound);
+				newIdx = EditorGUI.Popup(dropdownRect, "Sound", idx, titles.ToArray());
+			} else {
+				newIdx = EditorGUI.Popup(dropdownRect, "Sound", 0, titles.ToArray());
+			}
+
+			soundProperty.stringValue = titles[newIdx];
+		}
+
+		EditorGUI.BeginChangeCheck();
+		bool newCached = EditorGUI.Toggle(cachedRect, "Cached", cachedProperty.boolValue);
+		if (EditorGUI.EndChangeCheck())
+			cachedProperty.boolValue = newCached;
+
+		EditorGUI.BeginChangeCheck();
+		uint newMutations = (uint)EditorGUI.IntField(mutationsRect, "Mutations", mutationsProperty.intValue);
+		if (EditorGUI.EndChangeCheck())
+			mutationsProperty.intValue = (int)newMutations;
+
+		EditorGUI.BeginChangeCheck();
+		float newFactor = EditorGUI.FloatField(factorRect, "Mutation factor", factorProperty.floatValue);
+		if (EditorGUI.EndChangeCheck())
+			factorProperty.floatValue = newFactor;
+	}
+}

--- a/source/Editor/SfxrSoundEditor.cs
+++ b/source/Editor/SfxrSoundEditor.cs
@@ -20,12 +20,7 @@ public class SfxrSoundEditor : PropertyDrawer {
 	}
 
 	private void DrawFolded(Rect position, SerializedProperty property, GUIContent label) {
-		var soundProperty = property.FindPropertyRelative("sound");
-		string sound = soundProperty.stringValue;
-		if (string.IsNullOrEmpty(sound))
-			property.isExpanded = EditorGUI.Foldout(position, property.isExpanded, property.displayName + " (" + sound + ")");
-		else
-			property.isExpanded = EditorGUI.Foldout(position, property.isExpanded, property.displayName);
+		property.isExpanded = EditorGUI.Foldout(position, property.isExpanded, property.name);
 	}
 
 	private void DrawUnfolded(Rect position, SerializedProperty property, GUIContent label) {
@@ -43,10 +38,7 @@ public class SfxrSoundEditor : PropertyDrawer {
 		var soundContainer = SfxrSoundContainer.Create();
 
 		string soundTitle = soundProperty.stringValue;
-		if (string.IsNullOrEmpty(soundTitle))
-			property.isExpanded = EditorGUI.Foldout(labelRect, property.isExpanded, property.displayName);
-		else
-			property.isExpanded = EditorGUI.Foldout(labelRect, property.isExpanded, property.displayName + " (" + soundTitle + ")");
+		property.isExpanded = EditorGUI.Foldout(labelRect, property.isExpanded, property.name);
 
 		if (soundContainer.IsEmpty) {
 			EditorGUI.Popup(dropdownRect, "Sound", 0, new string[] { "-" });
@@ -70,9 +62,9 @@ public class SfxrSoundEditor : PropertyDrawer {
 			cachedProperty.boolValue = newCached;
 
 		EditorGUI.BeginChangeCheck();
-		uint newMutations = (uint)EditorGUI.IntField(mutationsRect, "Mutations", mutationsProperty.intValue);
+		int newMutations = EditorGUI.IntField(mutationsRect, "Mutations", mutationsProperty.intValue);
 		if (EditorGUI.EndChangeCheck())
-			mutationsProperty.intValue = (int)newMutations;
+			mutationsProperty.intValue = Mathf.Clamp(newMutations, 0, 100);
 
 		EditorGUI.BeginChangeCheck();
 		float newFactor = EditorGUI.FloatField(factorRect, "Mutation factor", factorProperty.floatValue);

--- a/source/SfxrSound.cs
+++ b/source/SfxrSound.cs
@@ -1,0 +1,49 @@
+﻿using UnityEngine;
+
+[System.Serializable]
+public class SfxrSound {
+	private SfxrSynth synthesizer = new SfxrSynth();
+
+	[SerializeField]
+	private string sound = null;
+
+	[SerializeField]
+	private bool cached = true;
+
+	[SerializeField]
+	private uint mutations = 0;
+	private bool HasMutations { get { return mutations > 0; } }
+
+	[SerializeField]
+	[Range(0f, 1f)]
+	private float mutationFactor = .05f;
+
+	private bool initialized = false;
+
+	public void Play() {
+		if (!initialized)
+			Initialize();
+
+		if (HasMutations)
+			synthesizer.PlayMutated(mutationFactor, mutations);
+		else
+			synthesizer.Play();
+	}
+
+	private void Initialize() {
+		string parameters = SfxrSoundContainer.Create().GetSound(sound);
+		synthesizer.parameters.SetSettingsString(parameters);
+		if (cached)
+			Cache();
+
+		initialized = true;
+	}
+
+	private void Cache() {
+		if (HasMutations)
+			synthesizer.CacheMutations(mutations, mutationFactor, () => synthesizer.PlayMutated(mutationFactor, mutations));
+		else
+			synthesizer.CacheSound(() => synthesizer.Play());
+	}
+
+}

--- a/source/SfxrSound.cs
+++ b/source/SfxrSound.cs
@@ -11,7 +11,8 @@ public class SfxrSound {
 	private bool cached = true;
 
 	[SerializeField]
-	private uint mutations = 0;
+	[Range(0, 100)]
+	private int mutations = 0;
 	private bool HasMutations { get { return mutations > 0; } }
 
 	[SerializeField]
@@ -25,7 +26,7 @@ public class SfxrSound {
 			Initialize();
 
 		if (HasMutations)
-			synthesizer.PlayMutated(mutationFactor, mutations);
+			synthesizer.PlayMutated(mutationFactor, (uint)mutations);
 		else
 			synthesizer.Play();
 	}
@@ -41,7 +42,7 @@ public class SfxrSound {
 
 	private void Cache() {
 		if (HasMutations)
-			synthesizer.CacheMutations(mutations, mutationFactor, () => synthesizer.PlayMutated(mutationFactor, mutations));
+			synthesizer.CacheMutations((uint)mutations, mutationFactor, () => synthesizer.PlayMutated(mutationFactor, (uint)mutations));
 		else
 			synthesizer.CacheSound(() => synthesizer.Play());
 	}

--- a/source/SfxrSoundContainer.cs
+++ b/source/SfxrSoundContainer.cs
@@ -54,6 +54,7 @@ public class SfxrSoundContainer {
 		return configs[actualTitle];
 	}
 
+#if UNITY_EDITOR
 	public void AddSound(string title, string parameters) {
 		string actualTitle = title.ToLowerInvariant();
 		configs.Add(actualTitle, parameters);
@@ -72,14 +73,12 @@ public class SfxrSoundContainer {
 		SaveToFile();
 	}
 
-#if UNITY_EDITOR
 	private void SaveToFile() {
 		string contents = ToString();
 		string filePath = Application.dataPath + "/Resources/usfxr_sounds.txt";
 		System.IO.File.WriteAllText(filePath, contents);
 		UnityEditor.AssetDatabase.Refresh();
 	}
-#endif
 
 	public override string ToString() {
 		System.Text.StringBuilder strBuilder = new System.Text.StringBuilder();
@@ -90,4 +89,5 @@ public class SfxrSoundContainer {
 
 		return strBuilder.ToString();
 	}
+#endif
 }

--- a/source/SfxrSoundContainer.cs
+++ b/source/SfxrSoundContainer.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+public class SfxrSoundContainer {
+	public static SfxrSoundContainer Create() {
+		string paramsList = ReadSoundsFile();
+		Dictionary<string, string> configurations = new Dictionary<string, string>();
+
+		string[] pairs = paramsList.Split(new string[] { "\n", "\r\n" }, System.StringSplitOptions.RemoveEmptyEntries);
+		for (int i = 0; i < pairs.Length; ++i) {
+			string[] vals = pairs[i].Split(':');
+			string title = vals[0];
+			string parameters = vals[1];
+
+			configurations.Add(title, parameters);
+		}
+
+		return new SfxrSoundContainer(configurations);
+	}
+
+	private static string ReadSoundsFile() {
+		TextAsset textFile = Resources.Load<TextAsset>("usfxr_sounds");
+		return !textFile ? string.Empty : textFile.text;
+	}
+
+	private Dictionary<string, string> configs = new Dictionary<string, string>();
+
+	private SfxrSoundContainer(Dictionary<string, string> entries) {
+		foreach (var kvp in entries)
+			configs.Add(kvp.Key.ToLowerInvariant(), kvp.Value);
+	}
+
+	public bool IsEmpty { get { return configs.Count == 0; } }
+
+	public bool Contains(string title) {
+		string actualTitle = title.ToLowerInvariant();
+		return configs.ContainsKey(actualTitle);
+	}
+
+	public string[] GetTitles() {
+		string[] titles = new string[configs.Count];
+
+		int i = 0;
+		foreach (var title in configs.Keys) {
+			titles[i] = title;
+			++i;
+		}
+
+		return titles;
+	}
+
+	public string GetSound(string title) {
+		string actualTitle = title.ToLowerInvariant();
+		return configs[actualTitle];
+	}
+
+	public void AddSound(string title, string parameters) {
+		string actualTitle = title.ToLowerInvariant();
+		configs.Add(actualTitle, parameters);
+		SaveToFile();
+	}
+
+	public void ReplaceSound(string title, string parameters) {
+		string actualTitle = title.ToLowerInvariant();
+		configs[actualTitle] = parameters;
+		SaveToFile();
+	}
+
+	public void DeleteSound(string title) {
+		string actualTitle = title.ToLowerInvariant();
+		configs.Remove(actualTitle);
+		SaveToFile();
+	}
+
+#if UNITY_EDITOR
+	private void SaveToFile() {
+		string contents = ToString();
+		string filePath = Application.dataPath + "/Resources/usfxr_sounds.txt";
+		System.IO.File.WriteAllText(filePath, contents);
+		UnityEditor.AssetDatabase.Refresh();
+	}
+#endif
+
+	public override string ToString() {
+		System.Text.StringBuilder strBuilder = new System.Text.StringBuilder();
+		var titles = new List<string>(configs.Keys);
+		titles.Sort();
+		foreach (var title in titles)
+			strBuilder.Append(title + ":" + configs[title] + System.Environment.NewLine);
+
+		return strBuilder.ToString();
+	}
+}


### PR DESCRIPTION
Hi.

I've added the option in SfxrGenerator to store sounds to a file in Resources called "usfxr_sounds.txt". This sounds can be loaded, replaced and deleted from there using the generator window.

A new Serializable class SfxrSound can be used to play those saved sounds. If used as a variable, it exposes a drop down list to choose which sound it should play.

Using this new type, the SpaceGame PlayerCube code would look like this:
```csharp
using UnityEngine;
using System.Collections;

public class PlayerCube : MonoBehaviour {
	
	private const int PLAYER_SPEED = 50; // units per second
	private const int SHOTS_PER_SECOND = 20;
	private const int SHOTS_WITH_AUDIO_PER_SECOND = 10; // Doesn't play audio on EVERY shot otherwise it's just a cacophony of audio effects

	[SerializeField]
	private SfxrSound fireSound = null;

	private float lastTimeFired;
	private float lastTimeFiredAudio;

	void Update() {
		float speedPassed = Time.deltaTime;
		if (Input.GetKey(KeyCode.W) || Input.GetKey(KeyCode.UpArrow))    transform.Translate(0, PLAYER_SPEED * speedPassed, 0);
		if (Input.GetKey(KeyCode.S) || Input.GetKey(KeyCode.DownArrow))  transform.Translate(0, PLAYER_SPEED * -speedPassed, 0);
		if (Input.GetKey(KeyCode.A) || Input.GetKey(KeyCode.LeftArrow))  transform.Translate(PLAYER_SPEED * -speedPassed, 0, 0);
		if (Input.GetKey(KeyCode.D) || Input.GetKey(KeyCode.RightArrow)) transform.Translate(PLAYER_SPEED * speedPassed, 0, 0);

		if (Input.GetKey(KeyCode.Space) && Time.realtimeSinceStartup > lastTimeFired + 1f/SHOTS_PER_SECOND) SpawnBullet();
	}

	private void SpawnBullet() {
		// Fire
		float now = Time.realtimeSinceStartup;

		Instantiate(Resources.Load("Prefabs/Bullet"), transform.position, Quaternion.identity);
		lastTimeFired = now;

		if (now > lastTimeFiredAudio + 1f/SHOTS_WITH_AUDIO_PER_SECOND) {
			this.fireSound.Play();
			lastTimeFiredAudio = now;
		}
	}
}
```

And in the editor it would look like this:
![usfxr_editsound](https://cloud.githubusercontent.com/assets/1529594/9965919/e933d232-5e39-11e5-888f-9c08a9cae38a.png)

I think this functionality moves usfxr, which is already quite useful into full Unity usability level.

If you think I should modify something, or tweak the functionality, let me know and I'll gladly do it.