### PR TITLE
Fixes

### DIFF
--- a/source/Editor/SfxrGenerator.cs
+++ b/source/Editor/SfxrGenerator.cs
@@ -77,7 +77,12 @@ public class SfxrGenerator : EditorWindow {
 	[MenuItem("Window/Generate usfxr Sound Effects")]
 	public static void Initialize() {
 		var window = ScriptableObject.CreateInstance<SfxrGenerator>();
-		window.title = window.name = "Sound Effects";
+		window.name = "Sound Effects";
+#if UNITY_4_0 || UNITY_4_1 || UNITY_4_2 || UNITY_4_3 || UNITY_4_4 || UNITY_4_5 || UNITY_4_6
+		window.title = window.name;
+#else
+		window.titleContent = new GUIContent(window.name);
+#endif
 		window.Show();
 	}
 

--- a/source/Editor/SfxrSoundEditor.cs
+++ b/source/Editor/SfxrSoundEditor.cs
@@ -37,7 +37,6 @@ public class SfxrSoundEditor : PropertyDrawer {
 
 		var soundContainer = SfxrSoundContainer.Create();
 
-		string soundTitle = soundProperty.stringValue;
 		property.isExpanded = EditorGUI.Foldout(labelRect, property.isExpanded, property.name);
 
 		if (soundContainer.IsEmpty) {

--- a/source/SfxrSoundContainer.cs
+++ b/source/SfxrSoundContainer.cs
@@ -76,6 +76,10 @@ public class SfxrSoundContainer {
 	private void SaveToFile() {
 		string contents = ToString();
 		string filePath = Application.dataPath + "/Resources/usfxr_sounds.txt";
+		System.IO.FileInfo file = new System.IO.FileInfo(filePath);
+		if (!file.Directory.Exists)
+			this.CreateDirectory(file.Directory);
+
 		System.IO.File.WriteAllText(filePath, contents);
 		UnityEditor.AssetDatabase.Refresh();
 	}
@@ -88,6 +92,13 @@ public class SfxrSoundContainer {
 			strBuilder.Append(title + ":" + configs[title] + System.Environment.NewLine);
 
 		return strBuilder.ToString();
+	}
+
+	private void CreateDirectory(System.IO.DirectoryInfo dir) {
+		if (!dir.Parent.Exists)
+			this.CreateDirectory(dir.Parent);
+
+		dir.Create();
 	}
 #endif
 }


### PR DESCRIPTION
Resources directory might no exist when creating new sounds.
Removed a couple of warnings (one only affecting Unity 5 and above).