### PR TITLE
Fixes to SfxrSound

### DIFF
--- a/source/Editor/SfxrSoundEditor.cs
+++ b/source/Editor/SfxrSoundEditor.cs
@@ -40,7 +40,7 @@ public class SfxrSoundEditor : PropertyDrawer {
 		property.isExpanded = EditorGUI.Foldout(labelRect, property.isExpanded, property.name);
 
 		if (soundContainer.IsEmpty) {
-			EditorGUI.Popup(dropdownRect, "Sound", 0, new string[] { "-" });
+			EditorGUI.Popup(dropdownRect, "Sound", 0, new string[] { "[No sounds saved]" });
 		} else {
 			string sound = soundProperty.stringValue;
 			List<string> titles = new List<string>(soundContainer.GetTitles());

--- a/source/SfxrSound.cs
+++ b/source/SfxrSound.cs
@@ -19,6 +19,7 @@ public class SfxrSound {
 	[Range(0f, 1f)]
 	private float mutationFactor = .05f;
 
+	[System.NonSerialized]
 	private bool initialized = false;
 
 	public void Play() {

--- a/source/SfxrSoundContainer.cs
+++ b/source/SfxrSoundContainer.cs
@@ -51,7 +51,11 @@ public class SfxrSoundContainer {
 
 	public string GetSound(string title) {
 		string actualTitle = title.ToLowerInvariant();
-		return configs[actualTitle];
+		if (configs.ContainsKey(actualTitle))
+			return configs[actualTitle];
+
+		Debug.LogError("No sound with title '" + title + "' found. Create it or verify it has not been removed.");
+		return ",,,,,,,,,,,,,,,,,,,,,,,";
 	}
 
 #if UNITY_EDITOR

--- a/source/SfxrSoundContainer.cs
+++ b/source/SfxrSoundContainer.cs
@@ -2,7 +2,14 @@
 using UnityEngine;
 
 public class SfxrSoundContainer {
+	private static SfxrSoundContainer container = null;
+
 	public static SfxrSoundContainer Create() {
+#if !UNITY_EDITOR
+		if (SfxrSoundContainer.container != null)
+			return SfxrSoundContainer.container;
+#endif
+
 		string paramsList = ReadSoundsFile();
 		Dictionary<string, string> configurations = new Dictionary<string, string>();
 
@@ -15,7 +22,8 @@ public class SfxrSoundContainer {
 			configurations.Add(title, parameters);
 		}
 
-		return new SfxrSoundContainer(configurations);
+		SfxrSoundContainer.container = new SfxrSoundContainer(configurations);
+		return SfxrSoundContainer.container;
 	}
 
 	private static string ReadSoundsFile() {


### PR DESCRIPTION
SfxrSound:
- Serialized the initialized variable, to avoid sounds failing to reproduce in the editor the second time a scene is played.
- When no sound is available, the sound selection drop down list writes "[No sounds saved]".

SfxrSoundContainer:
- If a sound name is not found, report it and return a zeroed parameters string, instead of throwing a KeyNotFoundException.
- The container is cached, to prevent multiple accesses to the Resources text asset.

I'm sorry I left all these bugs in my previous pull requests. I didn't have much time to thoroughly test them.